### PR TITLE
Ignore invalid tree entries

### DIFF
--- a/src/vfs.cc
+++ b/src/vfs.cc
@@ -19,7 +19,8 @@ SetupState Container::setup(const std::wstring &filename) {
 
   if (!vd.validate()) {
     // Some "dual layer" ISO files will have both a video and game partition
-    constexpr static size_t sc_gamePartitionOffset = 2048 * 32 * 6192;
+    constexpr static size_t sc_gamePartitionOffset =
+        xdvdfs::SECTOR_SIZE * 32 * 6192;
 
     stream->m_offset = sc_gamePartitionOffset;
 
@@ -82,7 +83,6 @@ Container::getFolderList(const std::filesystem::path &path) const {
 }
 
 void Container::build(xdvdfs::Stream &file, xdvdfs::FileEntry &dirent) {
-  // TODO consider std::filesystem::path::preferred_separator
   xdvdfs::FileEntry root("\\");
   auto newHandle = registerFileEntry(root, sc_invalidHandle);
 
@@ -96,17 +96,24 @@ void Container::buildFromTreeRecursive(xdvdfs::Stream &file,
 
   if (dirent.isDirectory()) {
     xdvdfs::FileEntry entry = dirent.getFirstEntry(file);
-    buildFromTreeRecursive(file, entry, newHandle);
+    if (entry.validate()) {
+      buildFromTreeRecursive(file, entry, newHandle);
+    }
   }
 
   if (dirent.hasLeftChild()) {
     xdvdfs::FileEntry entry = dirent.getLeftChild(file);
-    buildFromTreeRecursive(file, entry, parent);
+
+    if (entry.validate()) {
+      buildFromTreeRecursive(file, entry, parent);
+    }
   }
 
   if (dirent.hasRightChild()) {
     xdvdfs::FileEntry entry = dirent.getRightChild(file);
-    buildFromTreeRecursive(file, entry, parent);
+    if (entry.validate()) {
+      buildFromTreeRecursive(file, entry, parent);
+    }
   }
 }
 

--- a/src/xdvdfs.h
+++ b/src/xdvdfs.h
@@ -27,13 +27,16 @@ public:
   FileEntry(const FileEntry &other);
   FileEntry(const std::string &name);
 
-  void readFromFile(Stream &file, std::streampos pos, std::streamoff offset);
-  const std::string &getFilename() const;
-  uint32_t getFileSize() const;
+  void readFromFile(Stream &file, std::streampos sector, std::streamoff offset);
 
   // matching dokany api for now
   uint32_t read(Stream &file, void *buffer, uint32_t bufferlength,
                 int64_t offset) const;
+
+  bool validate() const;
+
+  const std::string &getFilename() const;
+  uint32_t getFileSize() const;
 
   uint8_t getAttributes() const { return m_attributes; }
   bool isDirectory() const;
@@ -52,8 +55,8 @@ public:
   static const uint8_t FILE_NORMAL = 0x80;
 
 private:
-  uint16_t m_leftSubTree{0};
-  uint16_t m_rightSubTree{0};
+  uint16_t m_leftSubTree{static_cast<uint16_t>(-1)};
+  uint16_t m_rightSubTree{static_cast<uint16_t>(-1)};
   uint32_t m_startSector{0};
   uint32_t m_fileSize{0};
   uint8_t m_attributes{0};
@@ -66,8 +69,9 @@ class VolumeDescriptor {
 public:
   void readFromFile(Stream &file);
 
-  bool validate();
-  FileEntry getRootDirEntry(Stream &file);
+  bool validate() const;
+
+  FileEntry getRootDirEntry(Stream &file) const;
   uint64_t getCreationTime() const { return m_filetime; }
 
 protected:


### PR DESCRIPTION
* Skip over invalid tree nodes, as suggested by a tool proposed [here](https://github.com/JayFoxRox/extract-xiso/blob/624847af8d73ec397575c8bad531223a048821b4/extract.py#L41-L64)
* Fixed reading filenames with an invalid length